### PR TITLE
chore: update deps, fix prisma client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 # Keep environment variables out of version control
 .env
+prisma/schema.prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@prisma/client": "^4.7.1",
         "express": "^4.18.2"
       },
       "devDependencies": {
         "@types/express": "^4.17.14",
         "@types/node": "^18.11.10",
         "nodemon": "^2.0.20",
+        "prisma": "^5.17.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"
       }
@@ -54,6 +56,82 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+      "integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
+      },
+      "engines": {
+        "node": ">=14.17"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.17.0.tgz",
+      "integrity": "sha512-l7+AteR3P8FXiYyo496zkuoiJ5r9jLQEdUuxIxNCN1ud8rdbH3GTxm+f+dCyaSv9l9WY+29L9czaVRXz9mULfg==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.17.0.tgz",
+      "integrity": "sha512-+r+Nf+JP210Jur+/X8SIPLtz+uW9YA4QO5IXA+KcSOBe/shT47bCcRMTYCbOESw3FFYFTwe7vU6KTWHKPiwvtg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/debug": "5.17.0",
+        "@prisma/engines-version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+        "@prisma/fetch-engine": "5.17.0",
+        "@prisma/get-platform": "5.17.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+      "integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/engines-version": {
+      "version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053.tgz",
+      "integrity": "sha512-tUuxZZysZDcrk5oaNOdrBnnkoTtmNQPkzINFDjz7eG6vcs9AVDmA/F6K5Plsb2aQc/l5M2EnFqn3htng9FA4hg==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.17.0.tgz",
+      "integrity": "sha512-ESxiOaHuC488ilLPnrv/tM2KrPhQB5TRris/IeIV4ZvUuKeaicCl4Xj/JCQeG9IlxqOgf1cCg5h5vAzlewN91Q==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.17.0",
+        "@prisma/engines-version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+        "@prisma/get-platform": "5.17.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/engines-version": {
+      "version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053.tgz",
+      "integrity": "sha512-tUuxZZysZDcrk5oaNOdrBnnkoTtmNQPkzINFDjz7eG6vcs9AVDmA/F6K5Plsb2aQc/l5M2EnFqn3htng9FA4hg==",
+      "devOptional": true
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.17.0.tgz",
+      "integrity": "sha512-UlDgbRozCP1rfJ5Tlkf3Cnftb6srGrEQ4Nm3og+1Se2gWmCZ0hmPIi+tQikGDUVLlvOWx3Gyi9LzgRP+HTXV9w==",
+      "devOptional": true,
+      "dependencies": {
+        "@prisma/debug": "5.17.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -871,6 +949,22 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prisma": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.17.0.tgz",
+      "integrity": "sha512-m4UWkN5lBE6yevqeOxEvmepnL5cNPEjzMw2IqDB59AcEV6w7D8vGljDLd1gPFH+W6gUxw9x7/RmN5dCS/WTPxA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "5.17.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1247,6 +1341,73 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@prisma/client": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.16.2.tgz",
+      "integrity": "sha512-qCoEyxv1ZrQ4bKy39GnylE8Zq31IRmm8bNhNbZx7bF2cU5aiCCnSa93J2imF88MBjn7J9eUQneNxUQVJdl/rPQ==",
+      "requires": {
+        "@prisma/engines-version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81"
+      }
+    },
+    "@prisma/debug": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.17.0.tgz",
+      "integrity": "sha512-l7+AteR3P8FXiYyo496zkuoiJ5r9jLQEdUuxIxNCN1ud8rdbH3GTxm+f+dCyaSv9l9WY+29L9czaVRXz9mULfg==",
+      "devOptional": true
+    },
+    "@prisma/engines": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.17.0.tgz",
+      "integrity": "sha512-+r+Nf+JP210Jur+/X8SIPLtz+uW9YA4QO5IXA+KcSOBe/shT47bCcRMTYCbOESw3FFYFTwe7vU6KTWHKPiwvtg==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/debug": "5.17.0",
+        "@prisma/engines-version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+        "@prisma/fetch-engine": "5.17.0",
+        "@prisma/get-platform": "5.17.0"
+      },
+      "dependencies": {
+        "@prisma/engines-version": {
+          "version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+          "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053.tgz",
+          "integrity": "sha512-tUuxZZysZDcrk5oaNOdrBnnkoTtmNQPkzINFDjz7eG6vcs9AVDmA/F6K5Plsb2aQc/l5M2EnFqn3htng9FA4hg==",
+          "devOptional": true
+        }
+      }
+    },
+    "@prisma/engines-version": {
+      "version": "4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81.tgz",
+      "integrity": "sha512-q617EUWfRIDTriWADZ4YiWRZXCa/WuhNgLTVd+HqWLffjMSPzyM5uOWoauX91wvQClSKZU4pzI4JJLQ9Kl62Qg=="
+    },
+    "@prisma/fetch-engine": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.17.0.tgz",
+      "integrity": "sha512-ESxiOaHuC488ilLPnrv/tM2KrPhQB5TRris/IeIV4ZvUuKeaicCl4Xj/JCQeG9IlxqOgf1cCg5h5vAzlewN91Q==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/debug": "5.17.0",
+        "@prisma/engines-version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+        "@prisma/get-platform": "5.17.0"
+      },
+      "dependencies": {
+        "@prisma/engines-version": {
+          "version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
+          "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053.tgz",
+          "integrity": "sha512-tUuxZZysZDcrk5oaNOdrBnnkoTtmNQPkzINFDjz7eG6vcs9AVDmA/F6K5Plsb2aQc/l5M2EnFqn3htng9FA4hg==",
+          "devOptional": true
+        }
+      }
+    },
+    "@prisma/get-platform": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.17.0.tgz",
+      "integrity": "sha512-UlDgbRozCP1rfJ5Tlkf3Cnftb6srGrEQ4Nm3og+1Se2gWmCZ0hmPIi+tQikGDUVLlvOWx3Gyi9LzgRP+HTXV9w==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/debug": "5.17.0"
       }
     },
     "@tsconfig/node10": {
@@ -1879,6 +2040,15 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "prisma": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.17.0.tgz",
+      "integrity": "sha512-m4UWkN5lBE6yevqeOxEvmepnL5cNPEjzMw2IqDB59AcEV6w7D8vGljDLd1gPFH+W6gUxw9x7/RmN5dCS/WTPxA==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/engines": "5.17.0"
+      }
     },
     "proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/express": "^4.17.14",
     "@types/node": "^18.11.10",
     "nodemon": "^2.0.20",
-    "prisma": "^4.7.1",
+    "prisma": "^5.17.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"
   },

--- a/src/dataSources/assetsDataSource.ts
+++ b/src/dataSources/assetsDataSource.ts
@@ -27,16 +27,10 @@ export class DBSyncAssetsDataSource implements AssetsDataSource {
         const multiAssets = await this.client.multi_asset.findMany({
             where: {
                 policy: Buffer.from(policyId, 'hex'),
-            },
-            include: {
-                ma_tx_mint: true,
             }
         });
         return multiAssets.map((m) => {
             const asset = mapAsset(m);
-            m.ma_tx_mint.forEach((t) => {
-                asset.quantity += t.quantity.toNumber();
-            });
             return asset;
         });
     }


### PR DESCRIPTION
Couldn't get the starter kit running. Followed the instructions step by step.

```bash
abc@romantic-employee-ytelkx-0:~/workspace/repo$ history
    3  npm install
    4  npx prisma init
    5  npx prisma db pull
    6  npx prisma generate
    7  npm run build
    8  npm run dev
```
After generating the `schema.prisma` and setting the `DATABASE_URL` i got the follwing errors:

1. `import { PrismaClient, multi_asset } from "@prisma/client";` Here `multi_asset` is not exported. So i tried to update the prisma package.
2. tsc complaining that `src/dataSources/assetsDataSource.ts:31:13 - error TS2322: Type '{ ma_tx_mint: true; }' is not assignable to type 'never'.`

I am a **newbie** and was just trying to get this to run but I might have deleted something I should not.

After this changes I managed to run `npm run build && npm run dev` and I was able to query a policy id.

